### PR TITLE
fix table

### DIFF
--- a/Configuration/TCA/Overrides/static_countries.php
+++ b/Configuration/TCA/Overrides/static_countries.php
@@ -1,7 +1,7 @@
 <?php
 // Use pre-8 LTS suggest options
 if (\TYPO3\CMS\Core\Utility\VersionNumberUtility::convertVersionNumberToInteger(\TYPO3\CMS\Core\Utility\VersionNumberUtility::getNumericTypo3Version()) < 8000000) {
-	$GLOBALS['TCA']['sys_countries']['columns']['cn_currency_uid']['config'] = [
+	$GLOBALS['TCA']['static_countries']['columns']['cn_currency_uid']['config'] = [
 		'type' => 'select',
 		'renderType' => 'selectSingle',
 		'items' => array(


### PR DESCRIPTION
there is no table 'sys_countries' as far as I can see. Don't know how it would be with TYPO3 v8 but with v7 I get an error in Backend.
Just guessing that this must be 'static_countries' rather then 'sys_countries'