### PR TITLE
[TASK] change php version restriction. allow php v7.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "typo3-ter/static-info-tables": "self.version"
   },
   "require": {
-    "php": ">= 7.0, <7.3",
+    "php": ">= 7.0, <7.4",
     "typo3/cms-core": ">=8.7, <10.0"
   },
   "autoload": {


### PR DESCRIPTION
Change php restriction in order to make it possible to use on installations with TYPO3 9 and PHP 7.3